### PR TITLE
create PusherLogAdapter to forward Pusher log calls to Laravel logger

### DIFF
--- a/config/pusher.php
+++ b/config/pusher.php
@@ -45,6 +45,7 @@ return [
             'host' => null,
             'port' => null,
             'timeout' => null,
+            'log' => false,
         ],
 
         'alternative' => [
@@ -55,6 +56,7 @@ return [
             'host' => null,
             'port' => null,
             'timeout' => null,
+            'log' => false,
         ],
 
     ],

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -55,6 +55,9 @@ class PusherFactory
             'port',
             'timeout',
         ];
+        $optionalKeys = [
+            'log'
+        ];
 
         foreach ($keys as $key) {
             if (!array_key_exists($key, $config)) {
@@ -62,7 +65,7 @@ class PusherFactory
             }
         }
 
-        return array_only($config, $keys);
+        return array_only($config, array_merge($keys, $optionalKeys));
     }
 
     /**
@@ -74,7 +77,7 @@ class PusherFactory
      */
     protected function getClient(array $auth)
     {
-        return new Pusher(
+        $pusher = new Pusher(
             $auth['auth_key'],
             $auth['secret'],
             $auth['app_id'],
@@ -83,5 +86,11 @@ class PusherFactory
             $auth['port'],
             $auth['timeout']
         );
+
+        if (isset($auth['log']) && $auth['log'] == true) {
+            $pusher->set_logger(app(PusherLogAdapter::class));
+        }
+
+        return $pusher;
     }
 }

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -56,7 +56,7 @@ class PusherFactory
             'timeout',
         ];
         $optionalKeys = [
-            'log'
+            'log',
         ];
 
         foreach ($keys as $key) {

--- a/src/PusherLogAdapter.php
+++ b/src/PusherLogAdapter.php
@@ -25,6 +25,7 @@ class PusherLogAdapter
 
     /**
      * PusherLogAdapter constructor.
+     *
      * @param Log $log
      */
     public function __construct(Log $log)
@@ -34,7 +35,9 @@ class PusherLogAdapter
 
     /**
      * Relay a message to the Laravel logger.
-     * @param String $message
+     *
+     * @param string $message
+     *
      * @return void
      */
     public function log($message)

--- a/src/PusherLogAdapter.php
+++ b/src/PusherLogAdapter.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Laravel Pusher.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Pusher;
+
+use Illuminate\Contracts\Logging\Log;
+
+/**
+ * This is a simple adapter so that log messages from the Pusher class can be redirected to Laravel's logger.
+ *
+ * @author Michal Carson <michal.carson@carsonsoftwareengineering.com>
+ */
+class PusherLogAdapter
+{
+    /** @var Log */
+    protected $log;
+
+    /**
+     * PusherLogAdapter constructor.
+     * @param Log $log
+     */
+    public function __construct(Log $log)
+    {
+        $this->log = $log;
+    }
+
+    /**
+     * Relay a message to the Laravel logger.
+     * @param String $message
+     * @return void
+     */
+    public function log($message)
+    {
+        $this->log->log('info', $message, []);
+    }
+}

--- a/tests/PusherFactoryTest.php
+++ b/tests/PusherFactoryTest.php
@@ -38,6 +38,24 @@ class PusherFactoryTest extends AbstractTestCase
         $this->assertInstanceOf(Pusher::class, $return);
     }
 
+    public function testMakeWithLogging()
+    {
+        $factory = $this->getPusherFactory();
+
+        $return = $factory->make([
+            'auth_key' => 'your-auth-key',
+            'secret' => 'your-secret',
+            'app_id' => 'your-app-id',
+            'options' => [],
+            'host' => null,
+            'port' => null,
+            'timeout' => null,
+            'log' => true,
+        ]);
+
+        $this->assertInstanceOf(Pusher::class, $return);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/PusherLogAdapterTest.php
+++ b/tests/PusherLogAdapterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Laravel Pusher.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vinkla\Tests\Pusher;
+
+use Illuminate\Contracts\Logging\Log;
+use Mockery;
+use Vinkla\Pusher\PusherLogAdapter;
+
+/**
+ * This is the Pusher Log Adapter test class.
+ *
+ * @author Michal Carson <michal.carson@carsonsoftwareengineering.com>
+ */
+class PusherFactoryTest extends AbstractTestCase
+{
+    public function testLog()
+    {
+        $logger = Mockery::mock(Log::class);
+        $logger->shouldReceive('log')->with('info', 'this message', [])->andReturnNull();
+
+        $adapter = new PusherLogAdapter($logger);
+
+        $adapter->log('this message');
+    }
+}

--- a/tests/PusherLogAdapterTest.php
+++ b/tests/PusherLogAdapterTest.php
@@ -20,7 +20,7 @@ use Vinkla\Pusher\PusherLogAdapter;
  *
  * @author Michal Carson <michal.carson@carsonsoftwareengineering.com>
  */
-class PusherFactoryTest extends AbstractTestCase
+class PusherLogAdapterTest extends AbstractTestCase
 {
     public function testLog()
     {

--- a/tests/PusherLogAdapterTest.php
+++ b/tests/PusherLogAdapterTest.php
@@ -30,5 +30,7 @@ class PusherLogAdapterTest extends AbstractTestCase
         $adapter = new PusherLogAdapter($logger);
 
         $adapter->log('this message');
+
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
The official Pusher package contains calls to a "log" method if a logger is provided. In this PR, I have provided a simple adapter class that will forward Pusher's log calls to the Laravel logger.

Activation of the log adapter is controlled by a true/false setting in config/pusher.php.

I've added two tests. One covers invocation of the Factory with log enabled. The other tests the single function of the log adapter ("log" method), assuring that it forwards the message to a mock logger.